### PR TITLE
Fix getting container names of versions in openshift namespace; popd; done

### DIFF
--- a/hack/build.sh
+++ b/hack/build.sh
@@ -23,8 +23,6 @@ test -z "$BASE_IMAGE_NAME" && {
   BASE_IMAGE_NAME="${BASE_DIR_NAME#sti-}"
 }
 
-NAMESPACE="openshift/"
-
 # Cleanup the temporary Dockerfile created by docker build with version
 trap "rm -f ${DOCKERFILE_PATH}.version" SIGINT SIGQUIT EXIT
 
@@ -59,7 +57,9 @@ dirs=${VERSION:-$VERSIONS}
 
 for dir in ${dirs}; do
   case " $OPENSHIFT_NAMESPACES " in
-    *\ ${dir}\ *) ;;
+    *\ ${dir}\ *)
+      NAMESPACE="openshift/"
+      ;;
     *)
       if [ "${OS}" == "centos7" ]; then
         NAMESPACE="centos/"


### PR DESCRIPTION
This PR fixes problem when version in openshift namespace  is not the lesser one (example of s2i-python-container). In this case, `NAMESPACE` variable is not set back to `openshift/` and created versions have wrong name.

@hhorak @bparees Same as sclorg/s2i-python-container#148. Please merge.
