### PR TITLE
Fix using subscription in container

### DIFF
--- a/4-perftools/Dockerfile.rhel7
+++ b/4-perftools/Dockerfile.rhel7
@@ -1,4 +1,4 @@
-FROM rhel7:7.2
+FROM rhel7
 MAINTAINER Red Hat, Inc.
 
 LABEL BZComponent="devtoolset-4-perftools-docker"
@@ -7,7 +7,10 @@ LABEL Version="4"
 LABEL Release="9"
 LABEL Architecture="x86_64"
 
-RUN yum-config-manager --enable rhel-server-rhscl-7-rpms && \
+# To use subscription inside container yum command has to be run first (before yum-config-manager)
+# https://access.redhat.com/solutions/1443553
+RUN yum repolist > /dev/null && \
+    yum-config-manager --enable rhel-server-rhscl-7-rpms && \
     yum-config-manager --enable rhel-7-server-optional-rpms && \
     yum-config-manager --disable epel >/dev/null || : && \
     INSTALL_PKGS="devtoolset-4-systemtap devtoolset-4-valgrind devtoolset-4-dyninst devtoolset-4-dyninst-devel devtoolset-4-elfutils devtoolset-4-elfutils-devel devtoolset-4-oprofile devtoolset-4-oprofile-jit devtoolset-4-oprofile-devel" && \

--- a/4-toolchain/Dockerfile.rhel7
+++ b/4-toolchain/Dockerfile.rhel7
@@ -1,4 +1,4 @@
-FROM rhel7:7.2
+FROM rhel7
 MAINTAINER Marek Polacek <polacek@redhat.com>
 
 LABEL io.k8s.description="Platform for building applications using Red Hat Developer Toolset 4" \
@@ -10,7 +10,10 @@ LABEL Version="4"
 LABEL Release="10.1"
 LABEL Architecture="x86_64"
 
-RUN yum-config-manager --enable rhel-server-rhscl-7-rpms && \
+# To use subscription inside container yum command has to be run first (before yum-config-manager)
+# https://access.redhat.com/solutions/1443553
+RUN yum repolist > /dev/null && \
+    yum-config-manager --enable rhel-server-rhscl-7-rpms && \
     yum-config-manager --enable rhel-7-server-optional-rpms && \
     yum-config-manager --disable epel >/dev/null || : && \
     INSTALL_PKGS="devtoolset-4-gcc devtoolset-4-gcc-c++ devtoolset-4-gcc-gfortran devtoolset-4-gdb" && \


### PR DESCRIPTION
Enabling host repositories didn't work with docker 1.10 and newer inside OpenStack. It was fixed in latest rhel7 base release, so using 'rhel7' base image is required for RHEL CI. Postgresql PR - sclorg/postgresql-container#150

Also to enable repositories inside container running 'yum' first is required - see https://access.redhat.com/solutions/1443553 . Similar to sclorg/s2i-base-container#99 .


@hhorak @bparees Please take a look and merge.