### PR TITLE
Skip 'ocount ls' testing if host does not support it.

### DIFF
--- a/4-perftools/test/run
+++ b/4-perftools/test/run
@@ -92,7 +92,16 @@ function test_sanity_ocount_run () {
   echo "Default perf event: $default_event"
 
   docker run --rm --privileged $IMAGE_NAME ocount -b ls &> $TMPDIR/actual-ocount
-  check_result "Exit code is zero" $? 0
+  local exit_code=$?
+
+  # Some environments may not provide perf events inside containers,
+  # it is necessary to check this in script.
+  if grep "Your kernel's Performance Events Subsystem does not support your processor type." $TMPDIR/actual-ocount &> /dev/null; then
+    info "Output contains ocount's complaints. Skipping."
+    return 0
+  fi
+
+  check_result "Exit code is zero" ${exit_code} 0
 
   echo "ocount output:"
   echo "----- ----- -----"
@@ -101,12 +110,6 @@ function test_sanity_ocount_run () {
 
   grep "$default_event" $TMPDIR/actual-ocount &> /dev/null
   check_result "at least, $default_event should appear in report" $? 0
-
-  # Keep these for later reference - some environments may not provide perf
-  # events inside containers, it may be necessary to tweak this script.
-  #
-  # grep "Your kernel's Performance Events Subsystem does not support your processor type." $TMPDIR/actual-ocount &> /dev/null
-  # check_result "Output contains ocount's complaints" $? 0
 }
 
 TMPDIR=`mktemp -d`


### PR DESCRIPTION
Some hosts does not support PMU events (for example coreservices-jenkins OpenStack).

So this PR allows skipping the test in that case. @hhorak Please merge.