### PR TITLE
Dockerfiles update

### DIFF
--- a/4-perftools/Dockerfile
+++ b/4-perftools/Dockerfile
@@ -21,7 +21,7 @@ USER 0
 
 WORKDIR ${HOME}
 
-ADD contrib/etc/scl_enable /root/etc/scl_enable
+COPY contrib/etc/scl_enable /root/etc/scl_enable
 
 # Enable the SCL for all bash scripts.
 ENV BASH_ENV=/root/etc/scl_enable \

--- a/4-perftools/Dockerfile
+++ b/4-perftools/Dockerfile
@@ -1,5 +1,17 @@
 FROM centos:centos7
-MAINTAINER Red Hat, Inc.
+LABEL MAINTAINER Red Hat, Inc.
+
+ENV SUMMARY="Developer Toolset 4 Performance Tools" \
+    DESCRIPTION="Performance tools: systemtap, valgrind, dyninst, elfutils, oprofile"
+
+LABEL com.redhat.component="devtoolset-4-perftools-docker" \
+      name="centos/devtoolset-4-perftools-centos7" \
+      version="4" \
+      release="1" \
+      summary="$SUMMARY" \
+      description="$DESCRIPTION" \
+      io.k8s.description="$DESCRIPTION" \
+      io.k8s.display-name="Devtoolset 4 Perftools"
 
 RUN yum install -y centos-release-scl-rh && \
     INSTALL_PKGS="devtoolset-4-systemtap devtoolset-4-valgrind devtoolset-4-dyninst devtoolset-4-dyninst-devel devtoolset-4-elfutils devtoolset-4-elfutils-devel devtoolset-4-oprofile devtoolset-4-oprofile-jit devtoolset-4-oprofile-devel" && \

--- a/4-perftools/Dockerfile
+++ b/4-perftools/Dockerfile
@@ -1,7 +1,7 @@
 FROM centos:centos7
 LABEL MAINTAINER Red Hat, Inc.
 
-ENV SUMMARY="Developer Toolset 4 Performance Tools" \
+ENV SUMMARY="Red Hat Developer Toolset 4 Performance Tools container image" \
     DESCRIPTION="Performance tools: systemtap, valgrind, dyninst, elfutils, oprofile"
 
 LABEL com.redhat.component="devtoolset-4-perftools-docker" \

--- a/4-perftools/Dockerfile.rhel7
+++ b/4-perftools/Dockerfile.rhel7
@@ -1,7 +1,7 @@
 FROM rhel7
 LABEL MAINTAINER Red Hat, Inc.
 
-ENV SUMMARY="Developer Toolset 4 Performance Tools" \
+ENV SUMMARY="Red Hat Developer Toolset 4 Performance Tools container image" \
     DESCRIPTION="Performance tools: systemtap, valgrind, dyninst, elfutils, oprofile"
 
 LABEL com.redhat.component="devtoolset-4-perftools-docker" \

--- a/4-perftools/Dockerfile.rhel7
+++ b/4-perftools/Dockerfile.rhel7
@@ -33,7 +33,7 @@ USER 0
 
 WORKDIR ${HOME}
 
-ADD contrib/etc/scl_enable /root/etc/scl_enable
+COPY contrib/etc/scl_enable /root/etc/scl_enable
 
 # Enable the SCL for all bash scripts.
 ENV BASH_ENV=/root/etc/scl_enable \

--- a/4-perftools/Dockerfile.rhel7
+++ b/4-perftools/Dockerfile.rhel7
@@ -1,12 +1,17 @@
 FROM rhel7
-MAINTAINER Red Hat, Inc.
+LABEL MAINTAINER Red Hat, Inc.
 
-# Labels consumed by Red Hat build service
-LABEL com.redhat.component="devtoolset-4-perftools-docker"
-LABEL name="rhscl/devtoolset-4-perftools-rhel7"
-LABEL version="4"
-LABEL release="1"
-LABEL architecture="x86_64"
+ENV SUMMARY="Developer Toolset 4 Performance Tools" \
+    DESCRIPTION="Performance tools: systemtap, valgrind, dyninst, elfutils, oprofile"
+
+LABEL com.redhat.component="devtoolset-4-perftools-docker" \
+      name="rhscl/devtoolset-4-perftools-rhel7" \
+      version="4" \
+      release="1" \
+      summary="$SUMMARY" \
+      description="$DESCRIPTION" \
+      io.k8s.description="$DESCRIPTION" \
+      io.k8s.display-name="Developer Toolset 4 Performance Tools"
 
 # To use subscription inside container yum command has to be run first (before yum-config-manager)
 # https://access.redhat.com/solutions/1443553

--- a/4-toolchain/Dockerfile
+++ b/4-toolchain/Dockerfile
@@ -31,12 +31,12 @@ WORKDIR ${HOME}
 
 # Use entrypoint so path is correctly adjusted already at the time the command
 # is searching, so something like docker run IMG gcc runs binary from SCL.
-ADD contrib/bin/container-entrypoint /usr/bin/container-entrypoint
+COPY contrib/bin/container-entrypoint /usr/bin/container-entrypoint
 
 # Install the usage script with base image usage informations
-ADD contrib/bin/usage /usr/local/bin/usage
+COPY contrib/bin/usage /usr/local/bin/usage
 
-ADD contrib/etc/scl_enable /opt/app-root/etc/scl_enable
+COPY contrib/etc/scl_enable /opt/app-root/etc/scl_enable
 
 # Enable the SCL for all bash scripts.
 ENV BASH_ENV=/opt/app-root/etc/scl_enable \

--- a/4-toolchain/Dockerfile
+++ b/4-toolchain/Dockerfile
@@ -2,7 +2,14 @@ FROM centos:centos7
 LABEL MAINTAINER Marek Polacek <polacek@redhat.com>
 
 ENV SUMMARY="Red Hat Developer Toolset 4 Toolchain container image" \
-    DESCRIPTION="Platform for building applications using Red Hat Developer Toolset 4"
+    DESCRIPTION="Platform for building C/C++ applications using Red Hat \
+Developer Toolset 4. Red Hat Developer Toolset is a Red Hat \
+offering for developers on the Red Hat Enterprise Linux platform. \
+It provides a complete set of development and performance analysis tools \
+that can be installed and used on multiple versions of Red Hat \
+Enterprise Linux. Executables built with the Red Hat Developer Toolset \
+toolchain can then also be deployed and run on multiple versions of \
+Red Hat Enterprise Linux."
 
 LABEL com.redhat.component="devtoolset-4-toolchain-docker" \
       name="centos/devtoolset-4-toolchain-centos7" \

--- a/4-toolchain/Dockerfile
+++ b/4-toolchain/Dockerfile
@@ -1,7 +1,7 @@
 FROM centos:centos7
 LABEL MAINTAINER Marek Polacek <polacek@redhat.com>
 
-ENV SUMMARY="Developer Toolset 4 Toolchain" \
+ENV SUMMARY="Red Hat Developer Toolset 4 Toolchain container image" \
     DESCRIPTION="Platform for building applications using Red Hat Developer Toolset 4"
 
 LABEL com.redhat.component="devtoolset-4-toolchain-docker" \

--- a/4-toolchain/Dockerfile
+++ b/4-toolchain/Dockerfile
@@ -1,7 +1,16 @@
 FROM centos:centos7
-MAINTAINER Marek Polacek <polacek@redhat.com>
+LABEL MAINTAINER Marek Polacek <polacek@redhat.com>
 
-LABEL io.k8s.description="Platform for building applications using Red Hat Developer Toolset 4" \
+ENV SUMMARY="Developer Toolset 4 Toolchain" \
+    DESCRIPTION="Platform for building applications using Red Hat Developer Toolset 4"
+
+LABEL com.redhat.component="devtoolset-4-toolchain-docker" \
+      name="centos/devtoolset-4-toolchain-centos7" \
+      version="4" \
+      release="1" \
+      summary="$SUMMARY" \
+      description="$DESCRIPTION" \
+      io.k8s.description="$DESCRIPTION" \
       io.k8s.display-name="Developer Toolset 4 Toolchain"
 
 RUN yum install -y centos-release-scl-rh && \

--- a/4-toolchain/Dockerfile.rhel7
+++ b/4-toolchain/Dockerfile.rhel7
@@ -2,7 +2,14 @@ FROM rhel7
 LABEL MAINTAINER Marek Polacek <polacek@redhat.com>
 
 ENV SUMMARY="Red Hat Developer Toolset 4 Toolchain container image" \
-    DESCRIPTION="Platform for building applications using Red Hat Developer Toolset 4"
+    DESCRIPTION="Platform for building C/C++ applications using Red Hat \
+Developer Toolset 4. Red Hat Developer Toolset is a Red Hat \
+offering for developers on the Red Hat Enterprise Linux platform. \
+It provides a complete set of development and performance analysis tools \
+that can be installed and used on multiple versions of Red Hat \
+Enterprise Linux. Executables built with the Red Hat Developer Toolset \
+toolchain can then also be deployed and run on multiple versions of \
+Red Hat Enterprise Linux."
 
 LABEL com.redhat.component="devtoolset-4-toolchain-docker" \
       name="rhscl/devtoolset-4-toolchain-rhel7" \

--- a/4-toolchain/Dockerfile.rhel7
+++ b/4-toolchain/Dockerfile.rhel7
@@ -43,12 +43,12 @@ WORKDIR ${HOME}
 
 # Use entrypoint so path is correctly adjusted already at the time the command
 # is searching, so something like docker run IMG gcc runs binary from SCL.
-ADD contrib/bin/container-entrypoint /usr/bin/container-entrypoint
+COPY contrib/bin/container-entrypoint /usr/bin/container-entrypoint
 
 # Install the usage script with base image usage informations
-ADD contrib/bin/usage /usr/local/bin/usage
+COPY contrib/bin/usage /usr/local/bin/usage
 
-ADD contrib/etc/scl_enable /opt/app-root/etc/scl_enable
+COPY contrib/etc/scl_enable /opt/app-root/etc/scl_enable
 
 # Enable the SCL for all bash scripts.
 ENV BASH_ENV=/opt/app-root/etc/scl_enable \

--- a/4-toolchain/Dockerfile.rhel7
+++ b/4-toolchain/Dockerfile.rhel7
@@ -1,15 +1,17 @@
 FROM rhel7
-MAINTAINER Marek Polacek <polacek@redhat.com>
+LABEL MAINTAINER Marek Polacek <polacek@redhat.com>
 
-LABEL io.k8s.description="Platform for building applications using Red Hat Developer Toolset 4" \
+ENV SUMMARY="Developer Toolset 4 Toolchain" \
+    DESCRIPTION="Platform for building applications using Red Hat Developer Toolset 4"
+
+LABEL com.redhat.component="devtoolset-4-toolchain-docker" \
+      name="rhscl/devtoolset-4-toolchain-rhel7" \
+      version="4" \
+      release="1" \
+      summary="$SUMMARY" \
+      description="$DESCRIPTION" \
+      io.k8s.description="$DESCRIPTION" \
       io.k8s.display-name="Developer Toolset 4 Toolchain"
-
-# Labels consumed by Red Hat build service
-LABEL com.redhat.component="devtoolset-4-toolchain-docker"
-LABEL name="rhscl/devtoolset-4-toolchain-rhel7"
-LABEL version="4"
-LABEL release="1"
-LABEL architecture="x86_64"
 
 # To use subscription inside container yum command has to be run first (before yum-config-manager)
 # https://access.redhat.com/solutions/1443553

--- a/4-toolchain/Dockerfile.rhel7
+++ b/4-toolchain/Dockerfile.rhel7
@@ -1,7 +1,7 @@
 FROM rhel7
 LABEL MAINTAINER Marek Polacek <polacek@redhat.com>
 
-ENV SUMMARY="Developer Toolset 4 Toolchain" \
+ENV SUMMARY="Red Hat Developer Toolset 4 Toolchain container image" \
     DESCRIPTION="Platform for building applications using Red Hat Developer Toolset 4"
 
 LABEL com.redhat.component="devtoolset-4-toolchain-docker" \

--- a/6-perftools/Dockerfile
+++ b/6-perftools/Dockerfile
@@ -1,7 +1,7 @@
 FROM centos:centos7
 LABEL MAINTAINER Red Hat, Inc.
 
-ENV SUMMARY="Developer Toolset 6 Performance Tools" \
+ENV SUMMARY="Red Hat Developer Toolset 6 Performance Tools container image" \
     DESCRIPTION="Performance tools: systemtap, valgrind, dyninst, elfutils, oprofile"
 
 LABEL com.redhat.component="devtoolset-6-perftools-docker" \

--- a/6-perftools/Dockerfile
+++ b/6-perftools/Dockerfile
@@ -21,7 +21,7 @@ USER 0
 
 WORKDIR ${HOME}
 
-ADD contrib/etc/scl_enable /root/etc/scl_enable
+COPY contrib/etc/scl_enable /root/etc/scl_enable
 
 # Enable the SCL for all bash scripts.
 ENV BASH_ENV=/root/etc/scl_enable \

--- a/6-perftools/Dockerfile
+++ b/6-perftools/Dockerfile
@@ -1,5 +1,18 @@
 FROM centos:centos7
-MAINTAINER Red Hat, Inc.
+LABEL MAINTAINER Red Hat, Inc.
+
+ENV SUMMARY="Developer Toolset 6 Performance Tools" \
+    DESCRIPTION="Performance tools: systemtap, valgrind, dyninst, elfutils, oprofile"
+
+LABEL com.redhat.component="devtoolset-6-perftools-docker" \
+      name="centos/devtoolset-6-perftools-centos7" \
+      version="6" \
+      release="1" \
+      summary="$SUMMARY" \
+      description="$DESCRIPTION" \
+      io.k8s.description="$DESCRIPTION" \
+      io.k8s.display-name="Developer Toolset 6 Performance Tools" \
+      io.k8s.min-memory="2Gi"
 
 RUN yum install -y centos-release-scl-rh && \
     INSTALL_PKGS="devtoolset-6-systemtap devtoolset-6-valgrind devtoolset-6-dyninst devtoolset-6-dyninst-devel devtoolset-6-elfutils devtoolset-6-elfutils-devel devtoolset-6-oprofile devtoolset-6-oprofile-jit devtoolset-6-oprofile-devel" && \

--- a/6-perftools/Dockerfile.rhel7
+++ b/6-perftools/Dockerfile.rhel7
@@ -1,7 +1,7 @@
 FROM rhel7
 LABEL MAINTAINER Red Hat, Inc.
 
-ENV SUMMARY="Developer Toolset 6 Performance Tools" \
+ENV SUMMARY="Red Hat Developer Toolset 6 Performance Tools container image" \
     DESCRIPTION="Performance tools: systemtap, valgrind, dyninst, elfutils, oprofile"
 
 LABEL com.redhat.component="devtoolset-6-perftools-docker" \

--- a/6-perftools/Dockerfile.rhel7
+++ b/6-perftools/Dockerfile.rhel7
@@ -1,14 +1,18 @@
 FROM rhel7
-MAINTAINER Red Hat, Inc.
+LABEL MAINTAINER Red Hat, Inc.
 
-LABEL com.redhat.component="devtoolset-6-perftools-docker"
-LABEL name="rhscl/devtoolset-6-perftools-rhel7"
-LABEL version="6"
-LABEL release="1"
-LABEL architecture="x86_64"
-LABEL io.k8s.description="Performance tools: systemtap, valgrind, dyninst, elfutils, oprofile"
-LABEL io.k8s.display-name="Developer Toolset 6 Performance Tools"
-LABEL io.k8s.min-memory="2Gi"
+ENV SUMMARY="Developer Toolset 6 Performance Tools" \
+    DESCRIPTION="Performance tools: systemtap, valgrind, dyninst, elfutils, oprofile"
+
+LABEL com.redhat.component="devtoolset-6-perftools-docker" \
+      name="rhscl/devtoolset-6-perftools-rhel7" \
+      version="6" \
+      release="1" \
+      summary="$SUMMARY" \
+      description="$DESCRIPTION" \
+      io.k8s.description="$DESCRIPTION" \
+      io.k8s.display-name="Developer Toolset 6 Performance Tools" \
+      io.k8s.min-memory="2Gi"
 
 # To use subscription inside container yum command has to be run first (before yum-config-manager)
 # https://access.redhat.com/solutions/1443553

--- a/6-perftools/Dockerfile.rhel7
+++ b/6-perftools/Dockerfile.rhel7
@@ -35,7 +35,7 @@ USER 0
 
 WORKDIR ${HOME}
 
-ADD contrib/etc/scl_enable /root/etc/scl_enable
+COPY contrib/etc/scl_enable /root/etc/scl_enable
 
 # Enable the SCL for all bash scripts.
 ENV BASH_ENV=/root/etc/scl_enable \

--- a/6-toolchain/Dockerfile
+++ b/6-toolchain/Dockerfile
@@ -30,12 +30,12 @@ WORKDIR ${HOME}
 
 # Use entrypoint so path is correctly adjusted already at the time the command
 # is searching, so something like docker run IMG gcc runs binary from SCL.
-ADD contrib/bin/container-entrypoint /usr/bin/container-entrypoint
+COPY contrib/bin/container-entrypoint /usr/bin/container-entrypoint
 
 # Install the usage script with base image usage informations
-ADD contrib/bin/usage /usr/local/bin/usage
+COPY contrib/bin/usage /usr/local/bin/usage
 
-ADD contrib/etc/scl_enable /opt/app-root/etc/scl_enable
+COPY contrib/etc/scl_enable /opt/app-root/etc/scl_enable
 
 # Enable the SCL for all bash scripts.
 ENV BASH_ENV=/opt/app-root/etc/scl_enable \

--- a/6-toolchain/Dockerfile
+++ b/6-toolchain/Dockerfile
@@ -1,7 +1,7 @@
 FROM centos:centos7
 LABEL MAINTAINER Marek Polacek <polacek@redhat.com>
 
-ENV SUMMARY="Developer Toolset 6 Toolchain" \
+ENV SUMMARY="Red Hat Developer Toolset 6 Toolchain container image" \
     DESCRIPTION="Platform for building applications using Red Hat Developer Toolset 6"
 
 LABEL com.redhat.component="devtoolset-6-toolchain-docker" \

--- a/6-toolchain/Dockerfile
+++ b/6-toolchain/Dockerfile
@@ -1,7 +1,16 @@
 FROM centos:centos7
-MAINTAINER Marek Polacek <polacek@redhat.com>
+LABEL MAINTAINER Marek Polacek <polacek@redhat.com>
 
-LABEL io.k8s.description="Platform for building applications using Red Hat Developer Toolset 6" \
+ENV SUMMARY="Developer Toolset 6 Toolchain" \
+    DESCRIPTION="Platform for building applications using Red Hat Developer Toolset 6"
+
+LABEL com.redhat.component="devtoolset-6-toolchain-docker" \
+      name="centos/devtoolset-6-toolchain-centos7" \
+      version="6" \
+      release="1" \
+      summary="$SUMMARY" \
+      description="$DESCRIPTION" \
+      io.k8s.description="$DESCRIPTION" \
       io.k8s.display-name="Developer Toolset 6 Toolchain"
 
 RUN yum install -y centos-release-scl-rh && \

--- a/6-toolchain/Dockerfile
+++ b/6-toolchain/Dockerfile
@@ -2,7 +2,14 @@ FROM centos:centos7
 LABEL MAINTAINER Marek Polacek <polacek@redhat.com>
 
 ENV SUMMARY="Red Hat Developer Toolset 6 Toolchain container image" \
-    DESCRIPTION="Platform for building applications using Red Hat Developer Toolset 6"
+    DESCRIPTION="Platform for building C/C++ applications using Red Hat \
+Developer Toolset 6. Red Hat Developer Toolset is a Red Hat \
+offering for developers on the Red Hat Enterprise Linux platform. \
+It provides a complete set of development and performance analysis tools \
+that can be installed and used on multiple versions of Red Hat \
+Enterprise Linux. Executables built with the Red Hat Developer Toolset \
+toolchain can then also be deployed and run on multiple versions of \
+Red Hat Enterprise Linux."
 
 LABEL com.redhat.component="devtoolset-6-toolchain-docker" \
       name="centos/devtoolset-6-toolchain-centos7" \

--- a/6-toolchain/Dockerfile.fedora
+++ b/6-toolchain/Dockerfile.fedora
@@ -1,10 +1,9 @@
 FROM fedora:25
-MAINTAINER Honza Horak <hhorak@redhat.com>
+LABEL MAINTAINER Honza Horak <hhorak@redhat.com>
 
-LABEL io.k8s.description="Platform for building C and C++ applications" \
-      io.k8s.display-name="Fedora variant of Developer Toolset's C/C++ Toolchain from Software Collections"
-
-ENV NAME=perftools \
+ENV SUMMARY="Fedora variant of Developer Toolset's C/C++ Toolchain from Software Collections" \
+    DESCRIPTION="Platform for building C and C++ applications" \
+    NAME=perftools \
     VERSION=1 \
     RELEASE=1 \
     ARCH=x86_64
@@ -14,6 +13,10 @@ LABEL com.redhat.component="$NAME" \
       version="$VERSION" \
       release="$RELEASE.$DISTTAG" \
       architecture="$ARCH" \
+      summary="$SUMMARY" \
+      description="$DESCRIPTION" \
+      io.k8s.description="$DESCRIPTION" \
+      io.k8s.display-name="Fedora variant of Developer Toolset's C/C++ Toolchain from Software Collections" \
       usage="docker run -ti -v /src/app:/opt/app-root/src:z f25/toolchain bash" \
       help="docker run IMAGE cat /help.1 | /usr/bin/groff -t -man -ETascii"
 

--- a/6-toolchain/Dockerfile.fedora
+++ b/6-toolchain/Dockerfile.fedora
@@ -1,7 +1,7 @@
 FROM fedora:25
 LABEL MAINTAINER Honza Horak <hhorak@redhat.com>
 
-ENV SUMMARY="Fedora variant of Developer Toolset's C/C++ Toolchain from Software Collections" \
+ENV SUMMARY="Fedora variant of Red Hat Developer Toolset's C/C++ Toolchain from Software Collections" \
     DESCRIPTION="Platform for building C and C++ applications" \
     NAME=perftools \
     VERSION=1 \

--- a/6-toolchain/Dockerfile.rhel7
+++ b/6-toolchain/Dockerfile.rhel7
@@ -42,12 +42,12 @@ WORKDIR ${HOME}
 
 # Use entrypoint so path is correctly adjusted already at the time the command
 # is searching, so something like docker run IMG gcc runs binary from SCL.
-ADD contrib/bin/container-entrypoint /usr/bin/container-entrypoint
+COPY contrib/bin/container-entrypoint /usr/bin/container-entrypoint
 
 # Install the usage script with base image usage informations
-ADD contrib/bin/usage /usr/local/bin/usage
+COPY contrib/bin/usage /usr/local/bin/usage
 
-ADD contrib/etc/scl_enable /opt/app-root/etc/scl_enable
+COPY contrib/etc/scl_enable /opt/app-root/etc/scl_enable
 
 # Enable the SCL for all bash scripts.
 ENV BASH_ENV=/opt/app-root/etc/scl_enable \

--- a/6-toolchain/Dockerfile.rhel7
+++ b/6-toolchain/Dockerfile.rhel7
@@ -1,7 +1,7 @@
 FROM rhel7
 LABEL MAINTAINER Marek Polacek <polacek@redhat.com>
 
-ENV SUMMARY="Developer Toolset 6 Toolchain" \
+ENV SUMMARY="Red Hat Developer Toolset 6 Toolchain container image" \
     DESCRIPTION="Platform for building applications using Red Hat Developer Toolset 6"
 
 LABEL com.redhat.component="devtoolset-6-toolchain-docker" \

--- a/6-toolchain/Dockerfile.rhel7
+++ b/6-toolchain/Dockerfile.rhel7
@@ -1,14 +1,17 @@
 FROM rhel7
-MAINTAINER Marek Polacek <polacek@redhat.com>
+LABEL MAINTAINER Marek Polacek <polacek@redhat.com>
 
-LABEL io.k8s.description="Platform for building applications using Red Hat Developer Toolset 6" \
+ENV SUMMARY="Developer Toolset 6 Toolchain" \
+    DESCRIPTION="Platform for building applications using Red Hat Developer Toolset 6"
+
+LABEL com.redhat.component="devtoolset-6-toolchain-docker" \
+      name="rhscl/devtoolset-6-toolchain-rhel7" \
+      version="6" \
+      release="1" \
+      summary="$SUMMARY" \
+      description="$DESCRIPTION" \
+      io.k8s.description="$DESCRIPTION" \
       io.k8s.display-name="Developer Toolset 6 Toolchain"
-
-LABEL com.redhat.component="devtoolset-6-toolchain-docker"
-LABEL name="rhscl/devtoolset-6-toolchain-rhel7"
-LABEL version="6"
-LABEL release="1"
-LABEL architecture="x86_64"
 
 # To use subscription inside container yum command has to be run first (before yum-config-manager)
 # https://access.redhat.com/solutions/1443553

--- a/6-toolchain/Dockerfile.rhel7
+++ b/6-toolchain/Dockerfile.rhel7
@@ -2,7 +2,14 @@ FROM rhel7
 LABEL MAINTAINER Marek Polacek <polacek@redhat.com>
 
 ENV SUMMARY="Red Hat Developer Toolset 6 Toolchain container image" \
-    DESCRIPTION="Platform for building applications using Red Hat Developer Toolset 6"
+    DESCRIPTION="Platform for building C/C++ applications using Red Hat \
+Developer Toolset 6. Red Hat Developer Toolset is a Red Hat \
+offering for developers on the Red Hat Enterprise Linux platform. \
+It provides a complete set of development and performance analysis tools \
+that can be installed and used on multiple versions of Red Hat \
+Enterprise Linux. Executables built with the Red Hat Developer Toolset \
+toolchain can then also be deployed and run on multiple versions of \
+Red Hat Enterprise Linux."
 
 LABEL com.redhat.component="devtoolset-6-toolchain-docker" \
       name="rhscl/devtoolset-6-toolchain-rhel7" \


### PR DESCRIPTION
Use COPY instruction instead of ADD
(COPY is preffered for simple usage - see https://docs.docker.com/engine/userguide/eng-image/dockerfile_best-practices/#add-or-copy)

Provide same labels for all base image variants (CentOS, RHEL, Fedora)
 - follow recomended labels from Project Atomic Container best practices
 - add summary and description labels (Fedora requirements) - use ENV for simple using of same value in more descriptive labels
 - remove architecture label for RHEL based images (this label is set in RHEL image - no need to define it again)


@mpolacek What should be values of `SUMMARY` and `DESCRIPTION`?

@hhorak @praiskup @pkubatrh Please take a look and merge.