### PR TITLE
Add support for centos6 devtoolset images 

### DIFF
--- a/4-perftools/Dockerfile.centos6
+++ b/4-perftools/Dockerfile.centos6
@@ -1,0 +1,43 @@
+FROM centos:centos6
+LABEL MAINTAINER Claudio Bantaloukas <rockdreamer@gmail.com>
+
+ENV SUMMARY="Red Hat Developer Toolset 4 Performance Tools container image" \
+    DESCRIPTION="Performance tools: systemtap, valgrind, dyninst, elfutils, oprofile"
+
+LABEL com.redhat.component="devtoolset-4-perftools-docker" \
+      name="centos/devtoolset-4-perftools-centos6" \
+      version="4" \
+      summary="$SUMMARY" \
+      description="$DESCRIPTION" \
+      io.k8s.description="$DESCRIPTION" \
+      io.k8s.display-name="Devtoolset 4 Perftools" \
+      io.k8s.min-memory="2Gi" \
+      usage="docker run -ti -v /bin:/host:ro centos/devtoolset-4-perftools-centos6 eu-objdump -d /host/<binary>"
+
+RUN yum install -y yum-utils centos-release-scl-rh && \
+    INSTALL_PKGS="devtoolset-4-systemtap devtoolset-4-valgrind devtoolset-4-dyninst devtoolset-4-dyninst-devel devtoolset-4-elfutils devtoolset-4-elfutils-devel devtoolset-4-oprofile devtoolset-4-oprofile-jit devtoolset-4-oprofile-devel" && \
+    yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
+    rpm -V $INSTALL_PKGS && \
+    yum clean all -y
+
+# Copy extra files to the image.
+COPY ./root/ /
+
+ENV HOME=/root \
+    PATH=/root/bin:/opt/rh/devtoolset-4/root/usr/bin/:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+
+RUN mkdir -p ${HOME} && \
+    chmod u+x /usr/bin/usage
+
+USER 0
+
+WORKDIR ${HOME}
+
+# Enable the SCL for all bash scripts.
+ENV BASH_ENV=/root/etc/scl_enable \
+    ENV=/root/etc/scl_enable \
+    PROMPT_COMMAND=". /root/etc/scl_enable"
+
+# Set the default CMD to print the usage of the perftools image
+ENTRYPOINT ["container-entrypoint"]
+CMD ["usage"]

--- a/4-perftools/test/run
+++ b/4-perftools/test/run
@@ -66,9 +66,9 @@ function test_sanity_valgrind_usage () {
 }
 
 function test_sanity_valgrind_run () {
-  info "Testing 'valgrind /foo/ls' usage ..."
+  info "Testing 'valgrind /bin/ls' usage ..."
 
-  docker run --rm -v /bin:/foo:ro $IMAGE_NAME valgrind /foo/ls &> $TMPDIR/actual-valgrind-run
+  docker run --rm $IMAGE_NAME valgrind /bin/ls &> $TMPDIR/actual-valgrind-run
   check_result "Exit code is zero" $? 0
 
   grep 'ERROR SUMMARY: 0 errors from 0 contexts' $TMPDIR/actual-valgrind-run &> /dev/null

--- a/4-toolchain/Dockerfile.centos6
+++ b/4-toolchain/Dockerfile.centos6
@@ -1,0 +1,54 @@
+FROM centos:centos6
+LABEL MAINTAINER Claudio Bantaloukas <rockdreamer@gmail.com>
+
+ENV SUMMARY="Red Hat Developer Toolset 4 Toolchain container image" \
+    DESCRIPTION="Platform for building C/C++ applications using Red Hat \
+Developer Toolset 4. Red Hat Developer Toolset is a Red Hat \
+offering for developers on the Red Hat Enterprise Linux platform. \
+It provides a complete set of development and performance analysis tools \
+that can be installed and used on multiple versions of Red Hat \
+Enterprise Linux. Executables built with the Red Hat Developer Toolset \
+toolchain can then also be deployed and run on multiple versions of \
+Red Hat Enterprise Linux."
+
+LABEL com.redhat.component="devtoolset-4-toolchain-docker" \
+      name="centos/devtoolset-4-toolchain-centos6" \
+      version="4" \
+      summary="$SUMMARY" \
+      description="$DESCRIPTION" \
+      io.k8s.description="$DESCRIPTION" \
+      io.k8s.display-name="Developer Toolset 4 Toolchain" \
+      usage="docker run -ti -v /src/app:/opt/app-root/src:z centos/devtoolset-4-toolchain-centos6 bash"
+
+RUN yum install -y centos-release-scl-rh && \
+    INSTALL_PKGS="devtoolset-4-gcc devtoolset-4-gcc-c++ devtoolset-4-gcc-gfortran devtoolset-4-gdb" && \
+    yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
+    rpm -V $INSTALL_PKGS && \
+    yum clean all -y
+
+
+# Copy extra files to the image.
+COPY ./root/ /
+
+ENV HOME=/opt/app-root/src \
+    PATH=/opt/app-root/src/bin:/opt/app-root/bin:/opt/rh/devtoolset-4/root/usr/bin/:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+
+RUN mkdir -p ${HOME} && \
+    groupadd -r default -f -g 1001 && \
+    useradd -u 1001 -r -g default -d ${HOME} -s /sbin/nologin \
+    -c "Default Application User" default && \
+    chown -R 1001:1001 /opt/app-root /usr/bin/container-entrypoint /usr/bin/usage && \
+    chmod u+x /usr/bin/usage
+
+USER 1001
+
+WORKDIR ${HOME}
+
+# Enable the SCL for all bash scripts.
+ENV BASH_ENV=/opt/app-root/etc/scl_enable \
+    ENV=/opt/app-root/etc/scl_enable \
+    PROMPT_COMMAND=". /opt/app-root/etc/scl_enable"
+
+# Set the default CMD to print the usage of the language image
+ENTRYPOINT ["container-entrypoint"]
+CMD ["usage"]

--- a/6-perftools/Dockerfile.centos6
+++ b/6-perftools/Dockerfile.centos6
@@ -1,0 +1,43 @@
+FROM centos:centos6
+LABEL MAINTAINER Claudio Bantaloukas <rockdreamer@gmail.com>
+
+ENV SUMMARY="Red Hat Developer Toolset 6 Performance Tools container image" \
+    DESCRIPTION="Performance tools: systemtap, valgrind, dyninst, elfutils, oprofile"
+
+LABEL com.redhat.component="devtoolset-6-perftools-docker" \
+      name="centos/devtoolset-6-perftools-centos6" \
+      version="6" \
+      summary="$SUMMARY" \
+      description="$DESCRIPTION" \
+      io.k8s.description="$DESCRIPTION" \
+      io.k8s.display-name="Developer Toolset 6 Performance Tools" \
+      io.k8s.min-memory="2Gi" \
+      usage="docker run -ti -v /bin:/host:ro centos/devtoolset-6-perftools-centos6 eu-objdump -d /host/<binary>"
+
+RUN yum install -y yum-utils centos-release-scl-rh && \
+    INSTALL_PKGS="devtoolset-6-systemtap devtoolset-6-valgrind devtoolset-6-dyninst devtoolset-6-dyninst-devel devtoolset-6-elfutils devtoolset-6-elfutils-devel devtoolset-6-oprofile devtoolset-6-oprofile-jit devtoolset-6-oprofile-devel" && \
+    yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
+    rpm -V $INSTALL_PKGS && \
+    yum clean all -y
+
+# Copy extra files to the image.
+COPY ./root/ /
+
+ENV HOME=/root \
+    PATH=/root/bin:/opt/rh/devtoolset-6/root/usr/bin/:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+
+RUN mkdir -p ${HOME} && \
+    chmod u+x /usr/bin/usage
+
+USER 0
+
+WORKDIR ${HOME}
+
+# Enable the SCL for all bash scripts.
+ENV BASH_ENV=/root/etc/scl_enable \
+    ENV=/root/etc/scl_enable \
+    PROMPT_COMMAND=". /root/etc/scl_enable"
+
+# Set the default CMD to print the usage of the perftools image
+ENTRYPOINT ["container-entrypoint"]
+CMD ["usage"]

--- a/6-perftools/test/run
+++ b/6-perftools/test/run
@@ -69,9 +69,9 @@ function test_sanity_valgrind_usage () {
 }
 
 function test_sanity_valgrind_run () {
-  info "Testing 'valgrind /foo/ls' usage ..."
+  info "Testing 'valgrind /bin/ls' usage ..."
 
-  docker run --rm -v /bin:/foo:ro $IMAGE_NAME valgrind /foo/ls &> $TMPDIR/actual-valgrind-run
+  docker run --rm $IMAGE_NAME valgrind /bin/ls &> $TMPDIR/actual-valgrind-run
   check_result "Exit code is zero" $? 0
 
   grep 'ERROR SUMMARY: 0 errors from 0 contexts' $TMPDIR/actual-valgrind-run &> /dev/null

--- a/6-toolchain/Dockerfile.centos6
+++ b/6-toolchain/Dockerfile.centos6
@@ -1,0 +1,53 @@
+FROM centos:centos6
+LABEL MAINTAINER Claudio Bantaloukas <rockdreamer@gmail.com>
+
+ENV SUMMARY="Red Hat Developer Toolset 6 Toolchain container image" \
+    DESCRIPTION="Platform for building C/C++ applications using Red Hat \
+Developer Toolset 6. Red Hat Developer Toolset is a Red Hat \
+offering for developers on the Red Hat Enterprise Linux platform. \
+It provides a complete set of development and performance analysis tools \
+that can be installed and used on multiple versions of Red Hat \
+Enterprise Linux. Executables built with the Red Hat Developer Toolset \
+toolchain can then also be deployed and run on multiple versions of \
+Red Hat Enterprise Linux."
+
+LABEL com.redhat.component="devtoolset-6-toolchain-docker" \
+      name="centos/devtoolset-6-toolchain-centos7" \
+      version="6" \
+      summary="$SUMMARY" \
+      description="$DESCRIPTION" \
+      io.k8s.description="$DESCRIPTION" \
+      io.k8s.display-name="Developer Toolset 6 Toolchain" \
+      usage="docker run -ti -v /src/app:/opt/app-root/src:z centos/devtoolset-6-toolchain-centos7 bash"
+
+RUN yum install -y centos-release-scl-rh && \
+    INSTALL_PKGS="devtoolset-6-gcc devtoolset-6-gcc-c++ devtoolset-6-gcc-gfortran devtoolset-6-gdb" && \
+    yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
+    rpm -V $INSTALL_PKGS && \
+    yum clean all -y
+
+# Copy extra files to the image.
+COPY ./root/ /
+
+ENV HOME=/opt/app-root/src \
+    PATH=/opt/app-root/src/bin:/opt/app-root/bin:/opt/rh/devtoolset-6/root/usr/bin/:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+
+RUN mkdir -p ${HOME} && \
+    groupadd -r default -f -g 1001 && \
+    useradd -u 1001 -r -g default -d ${HOME} -s /sbin/nologin \
+    -c "Default Application User" default && \
+    chown -R 1001:1001 /opt/app-root /usr/bin/container-entrypoint /usr/bin/usage && \
+    chmod u+x /usr/bin/usage
+
+USER 1001
+
+WORKDIR ${HOME}
+
+# Enable the SCL for all bash scripts.
+ENV BASH_ENV=/opt/app-root/etc/scl_enable \
+    ENV=/opt/app-root/etc/scl_enable \
+    PROMPT_COMMAND=". /opt/app-root/etc/scl_enable"
+
+# Set the default CMD to print the usage of the language image
+ENTRYPOINT ["container-entrypoint"]
+CMD ["usage"]

--- a/6-toolchain/Dockerfile.centos6
+++ b/6-toolchain/Dockerfile.centos6
@@ -12,13 +12,13 @@ toolchain can then also be deployed and run on multiple versions of \
 Red Hat Enterprise Linux."
 
 LABEL com.redhat.component="devtoolset-6-toolchain-docker" \
-      name="centos/devtoolset-6-toolchain-centos7" \
+      name="centos/devtoolset-6-toolchain-centos6" \
       version="6" \
       summary="$SUMMARY" \
       description="$DESCRIPTION" \
       io.k8s.description="$DESCRIPTION" \
       io.k8s.display-name="Developer Toolset 6 Toolchain" \
-      usage="docker run -ti -v /src/app:/opt/app-root/src:z centos/devtoolset-6-toolchain-centos7 bash"
+      usage="docker run -ti -v /src/app:/opt/app-root/src:z centos/devtoolset-6-toolchain-centos6 bash"
 
 RUN yum install -y centos-release-scl-rh && \
     INSTALL_PKGS="devtoolset-6-gcc devtoolset-6-gcc-c++ devtoolset-6-gcc-gfortran devtoolset-6-gdb" && \

--- a/7-perftools/Dockerfile.centos6
+++ b/7-perftools/Dockerfile.centos6
@@ -1,0 +1,44 @@
+FROM centos:centos6
+LABEL MAINTAINER Claudio Bantaloukas <rockdreamer@gmail.com>
+
+ENV SUMMARY="Red Hat Developer Toolset 7 Performance Tools container image" \
+    DESCRIPTION="Performance tools: systemtap, valgrind, dyninst, elfutils, oprofile"
+
+LABEL com.redhat.component="devtoolset-7-perftools-docker" \
+      name="centos/devtoolset-7-perftools-centos6" \
+      version="7" \
+      summary="$SUMMARY" \
+      description="$DESCRIPTION" \
+      io.k8s.description="$DESCRIPTION" \
+      io.k8s.display-name="Developer Toolset 7 Performance Tools" \
+      io.k8s.min-memory="2Gi" \
+      usage="docker run -ti -v /bin:/host:ro centos/devtoolset-7-perftools-centos6 eu-objdump -d /host/<binary>"
+
+RUN yum install -y yum-utils centos-release-scl-rh && \
+    yum-config-manager --enable centos-sclo-rh-testing && \
+    INSTALL_PKGS="devtoolset-7-systemtap devtoolset-7-valgrind devtoolset-7-dyninst devtoolset-7-dyninst-devel devtoolset-7-elfutils devtoolset-7-elfutils-devel devtoolset-7-oprofile devtoolset-7-oprofile-jit devtoolset-7-oprofile-devel" && \
+    yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
+    rpm -V $INSTALL_PKGS && \
+    yum clean all -y
+
+# Copy extra files to the image.
+COPY ./root/ /
+
+ENV HOME=/root \
+    PATH=/root/bin:/opt/rh/devtoolset-7/root/usr/bin/:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+
+RUN mkdir -p ${HOME} && \
+    chmod u+x /usr/bin/usage
+
+USER 0
+
+WORKDIR ${HOME}
+
+# Enable the SCL for all bash scripts.
+ENV BASH_ENV=/root/etc/scl_enable \
+    ENV=/root/etc/scl_enable \
+    PROMPT_COMMAND=". /root/etc/scl_enable"
+
+# Set the default CMD to print the usage of the perftools image
+ENTRYPOINT ["container-entrypoint"]
+CMD ["usage"]

--- a/7-perftools/test/run
+++ b/7-perftools/test/run
@@ -69,9 +69,9 @@ function test_sanity_valgrind_usage () {
 }
 
 function test_sanity_valgrind_run () {
-  info "Testing 'valgrind /foo/ls' usage ..."
+  info "Testing 'valgrind /bin/ls' usage ..."
 
-  docker run --rm -v /bin:/foo:ro $IMAGE_NAME valgrind /foo/ls &> $TMPDIR/actual-valgrind-run
+  docker run --rm -v /bin:/foo:ro $IMAGE_NAME valgrind /bin/ls &> $TMPDIR/actual-valgrind-run
   check_result "Exit code is zero" $? 0
 
   grep 'ERROR SUMMARY: 0 errors from 0 contexts' $TMPDIR/actual-valgrind-run &> /dev/null

--- a/7-toolchain/Dockerfile.centos6
+++ b/7-toolchain/Dockerfile.centos6
@@ -1,0 +1,54 @@
+FROM centos:centos6
+LABEL MAINTAINER Claudio Bantaloukas <rockdreamer@gmail.com>
+
+ENV SUMMARY="Red Hat Developer Toolset 7 Toolchain container image" \
+    DESCRIPTION="Platform for building C/C++ applications using Red Hat \
+Developer Toolset 7. Red Hat Developer Toolset is a Red Hat \
+offering for developers on the Red Hat Enterprise Linux platform. \
+It provides a complete set of development and performance analysis tools \
+that can be installed and used on multiple versions of Red Hat \
+Enterprise Linux. Executables built with the Red Hat Developer Toolset \
+toolchain can then also be deployed and run on multiple versions of \
+Red Hat Enterprise Linux."
+
+LABEL com.redhat.component="devtoolset-7-toolchain-docker" \
+      name="centos/devtoolset-7-toolchain-centos6" \
+      version="7" \
+      summary="$SUMMARY" \
+      description="$DESCRIPTION" \
+      io.k8s.description="$DESCRIPTION" \
+      io.k8s.display-name="Developer Toolset 7 Toolchain" \
+      usage="docker run -ti -v /src/app:/opt/app-root/src:z centos/devtoolset-7-toolchain-centos6 bash"
+
+RUN yum install -y yum-utils centos-release-scl-rh && \
+    yum-config-manager --enable centos-sclo-rh-testing && \
+    INSTALL_PKGS="devtoolset-7-gcc devtoolset-7-gcc-c++ devtoolset-7-gcc-gfortran devtoolset-7-gdb" && \
+    yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
+    rpm -V $INSTALL_PKGS && \
+    yum clean all -y
+
+# Copy extra files to the image.
+COPY ./root/ /
+
+ENV HOME=/opt/app-root/src \
+    PATH=/opt/app-root/src/bin:/opt/app-root/bin:/opt/rh/devtoolset-7/root/usr/bin/:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+
+RUN mkdir -p ${HOME} && \
+    groupadd -r default -f -g 1001 && \
+    useradd -u 1001 -r -g default -d ${HOME} -s /sbin/nologin \
+    -c "Default Application User" default && \
+    chown -R 1001:1001 /opt/app-root /usr/bin/container-entrypoint /usr/bin/usage && \
+    chmod u+x /usr/bin/usage
+
+USER 1001
+
+WORKDIR ${HOME}
+
+# Enable the SCL for all bash scripts.
+ENV BASH_ENV=/opt/app-root/etc/scl_enable \
+    ENV=/opt/app-root/etc/scl_enable \
+    PROMPT_COMMAND=". /opt/app-root/etc/scl_enable"
+
+# Set the default CMD to print the usage of the language image
+ENTRYPOINT ["container-entrypoint"]
+CMD ["usage"]

--- a/README.md
+++ b/README.md
@@ -23,11 +23,12 @@ RHEL versions currently supported are:
 
 CentOS versions currently supported are:
 * CentOS7
+* CentOS6
 
 
 Installation
 ----------------------
-Choose either the CentOS7 or RHEL7 based image:
+Choose either the Centos6, CentOS7 or RHEL7 based image:
 
 *  **RHEL7 based image**
 
@@ -66,6 +67,16 @@ Choose either the CentOS7 or RHEL7 based image:
     $ make build TARGET=centos7 VERSIONS=7-toolchain
     ```
 
+*  **CentOS6 based image**
+
+    To build a CentOS6 based DevToolset Toolchain image from scratch run:
+
+    ```
+    $ git clone --recursive https://github.com/sclorg/devtoolset-container.git
+    $ cd devtoolset-container
+    $ git submodule update --init
+    $ make build TARGET=centos6 VERSIONS=7-toolchain
+    ```
 For using other versions or variants of DevToolset Toolchain, just replace the `7-toolchain` value by particular version
 in the commands above.
 


### PR DESCRIPTION
The first commit is there to allow running the tests from a recent linux distribution. If the host's /bin/ls is using a recent glibc version, running it under valgrind in the centos6 container fails due to missing symbols. While this test fails to demonstrate usage of valgrind with a binary in an imported volume, it provides a basic test that valgrind works.

The centos6 Dockerfiles are similar to the centos7 ones, with the addition of the yum-utils package.

At your disposal for any questions, critiques.
Please note that this patch depends on having an updated copy of the common repository